### PR TITLE
fix: Invalid prop outline on native platforms

### DIFF
--- a/src/text-input.tsx
+++ b/src/text-input.tsx
@@ -10,6 +10,7 @@ import {
 import * as React from 'react'
 import { ReactNode } from 'react'
 import {
+  Platform,
   Text,
   TextInput as RNTextInput,
   TextInputProps as RNTextInputProps,
@@ -19,7 +20,7 @@ import { styles as s } from 'tachyons-react-native'
 
 const styles = {
   spacer: { padding: 4 },
-  input: [s.flex, s.f5, { outline: 0 }],
+  input: [s.flex, s.f5, Platform.select({web:{outlineWidth:0}})],
   outerContainer: [s.pv1],
   innerContainer: [s.ba, s.flexRow, s.itemsCenter],
   icon: [s.justifyCenter, s.itemsCenter, s.ph2],

--- a/src/text-input.tsx
+++ b/src/text-input.tsx
@@ -20,7 +20,7 @@ import { styles as s } from 'tachyons-react-native'
 
 const styles = {
   spacer: { padding: 4 },
-  input: [s.flex, s.f5, Platform.select({web:{outlineWidth:0}})],
+  input: [s.flex, s.f5, Platform.select({ web: { outlineWidth: 0 } })],
   outerContainer: [s.pv1],
   innerContainer: [s.ba, s.flexRow, s.itemsCenter],
   icon: [s.justifyCenter, s.itemsCenter, s.ph2],


### PR DESCRIPTION
## Description
Fixes invalid prop warning on native platforms.
```
 ERROR  Warning: Failed prop type: Invalid props.style key `outline` supplied to `ForwardRef(TextInput)`.
Bad object: {
  "color": "#202D42",
  "padding": 4,
  "flex": 1,
  "fontSize": 16,
  "outline": 0,
  "minHeight": 100,
  "maxHeight": 150
}
```

## Change log

- Updated style rule to set outlineWidth as zero only on web platform